### PR TITLE
Fix joystick repetition in menu

### DIFF
--- a/data/scripts/dialog_box.lua
+++ b/data/scripts/dialog_box.lua
@@ -11,6 +11,7 @@ local quest_manager = require("scripts/quest_manager")
 -- Creates and sets up a dialog box for the specified game.
 function dialog_box_manager:create(game)
 
+  local last_joy_axis_move = { 0, 0 }
   local dialog_box = {
 
     -- Dialog box properties.
@@ -524,6 +525,15 @@ function dialog_box_manager:create(game)
 
     -- Don't propagate the event to anything below the dialog box.
     return true
+  end
+
+  function dialog_box:on_joypad_axis_moved(axis, state)
+
+    -- Avoid move repetition
+    local handled = last_joy_axis_move[axis % 2] == state
+    last_joy_axis_move[axis % 2] = state
+
+    return handled
   end
 
   function dialog_box:on_draw(dst_surface)

--- a/data/scripts/menus/language.lua
+++ b/data/scripts/menus/language.lua
@@ -2,6 +2,7 @@
 -- If a language is already set, we skip this menu.
 
 local language_menu = {}
+local last_joy_axis_move = { 0, 0 }
 
 local quest_manager = require("scripts/quest_manager.lua")
 
@@ -108,19 +109,27 @@ end
 
 function language_menu:on_joypad_axis_moved(axis, state)
 
-  if axis % 2 == 0 then  -- Horizontal axis.
-    if state > 0 then
-      self:direction_pressed(0)
-    elseif state < 0 then
-      self:direction_pressed(4)
-    end
-  else  -- Vertical axis.
-    if state > 0 then
-      self:direction_pressed(6)
-    elseif state < 0 then
-      self:direction_pressed(2)
+  -- Avoid move repetition
+  local handled = last_joy_axis_move[axis % 2] == state
+  last_joy_axis_move[axis % 2] = state
+
+  if not handled then
+    if axis % 2 == 0 then  -- Horizontal axis.
+      if state > 0 then
+        self:direction_pressed(0)
+      elseif state < 0 then
+        self:direction_pressed(4)
+      end
+    else  -- Vertical axis.
+      if state > 0 then
+        self:direction_pressed(6)
+      elseif state < 0 then
+        self:direction_pressed(2)
+      end
     end
   end
+
+  return handled
 end
 
 function language_menu:on_joypad_hat_moved(hat, direction8)

--- a/data/scripts/menus/lib/gui_designer.lua
+++ b/data/scripts/menus/lib/gui_designer.lua
@@ -234,25 +234,35 @@ end
 -- and any joypad button event is replaced by a spacebar keyboard event.
 function gui_designer:map_joypad_to_keyboard(menu)
 
+  local last_joy_axis_move = { 0, 0 }
+
   function menu:on_joypad_button_pressed(button)
     return self:on_key_pressed("space")
   end
 
   function menu:on_joypad_axis_moved(axis, state)
 
-    if axis % 2 == 0 then  -- Horizontal axis.
-      if state > 0 then
-        return self:on_key_pressed("right")
-      elseif state < 0 then
-        return self:on_key_pressed("left")
-      end
-    else  -- Vertical axis.
-      if state > 0 then
-        return self:on_key_pressed("down")
-      elseif state < 0 then
-        return self:on_key_pressed("up")
+    -- Avoid move repetition
+    local handled = last_joy_axis_move[axis % 2] == state
+    last_joy_axis_move[axis % 2] = state
+
+    if not handled then
+        if axis % 2 == 0 then  -- Horizontal axis.
+          if state > 0 then
+            return self:on_key_pressed("right")
+          elseif state < 0 then
+            return self:on_key_pressed("left")
+          end
+        else  -- Vertical axis.
+          if state > 0 then
+            return self:on_key_pressed("down")
+          elseif state < 0 then
+            return self:on_key_pressed("up")
+        end
       end
     end
+
+    return handled
   end
 
   function menu:on_joypad_hat_moved(hat, direction8)

--- a/data/scripts/menus/pause.lua
+++ b/data/scripts/menus/pause.lua
@@ -5,6 +5,7 @@
 -- local pause_menu = pause_manager:create(game)
 
 local pause_manager = {}
+local last_joy_axis_move = { 0, 0 }
 
 -- Creates a pause menu for the specified game.
 function pause_manager:create(game)
@@ -140,6 +141,15 @@ function pause_manager:create(game)
       game:set_paused(false)
       handled = true
     end
+    return handled
+  end
+
+  function pause_menu:on_joypad_axis_moved(axis, state)
+
+    -- Avoid move repetition
+    local handled = last_joy_axis_move[axis % 2] == state
+    last_joy_axis_move[axis % 2] = state
+
     return handled
   end
 


### PR DESCRIPTION
Fix joystick repetition in menu by stopping propagation of "axis moved" event